### PR TITLE
debug pc update constraint

### DIFF
--- a/air/src/constraints.rs
+++ b/air/src/constraints.rs
@@ -121,16 +121,14 @@ impl<E: FieldElement + From<Felt>> EvaluationResult<E> for [E] {
         // pc constraints
         self[NEXT_PC_1] =
             (curr.t1() - curr.f_pc_jnz()) * (next.pc() - (curr.pc() + curr.inst_size()));
-        // FIXME: Constraint (5) on page 53 is not evaluating to zero, so we cannot combine
-        // constraints (5) and (6) below
-        self[NEXT_PC_2] = curr.t0() * (next.pc() - (curr.pc() + curr.op1()));
-        //    + (one - curr.f_pc_jnz()) * next.pc()
-        //    - (one - curr.f_pc_abs() - curr.f_pc_rel() - curr.f_pc_jnz())
-        //        * (curr.pc() + curr.inst_size())
-        //    + curr.f_pc_abs() * curr.res()
-        //    + curr.f_pc_rel() * (curr.pc() + curr.res());
+        self[NEXT_PC_2] = curr.t0() * (next.pc() - (curr.pc() + curr.op1()))
+           + (one - curr.f_pc_jnz()) * next.pc()
+           - ((one - curr.f_pc_abs() - curr.f_pc_rel() - curr.f_pc_jnz())
+                   * (curr.pc() + curr.inst_size())
+               + curr.f_pc_abs() * curr.res()
+               + curr.f_pc_rel() * (curr.pc() + curr.res()));
         self[T0] = curr.f_pc_jnz() * curr.dst() - curr.t0();
-        self[T1] = curr.t0() * curr.res();
+        self[T1] = curr.t0() * curr.res() - curr.t1();
     }
 
     fn evaluate_opcode_constraints(&mut self, frame: &MainEvaluationFrame<E>) {

--- a/runner/src/trace.rs
+++ b/runner/src/trace.rs
@@ -114,11 +114,7 @@ impl ExecutionTrace {
             // TODO: Don't hardcode index values
             let f_pc_jnz = state.flags[9][step];
             let dst = state.mem_v[1][step];
-            let res = if f_pc_jnz != Felt::ZERO && dst != Felt::ZERO {
-                dst.inv()
-            } else {
-                state.res[0][step]
-            };
+            let res = state.res[0][step];
             t0.push(f_pc_jnz * dst); // f_pc_jnz * dst
             t1.push(t0[step] * res); // t_0 * res
             mul.push(state.mem_v[2][step] * state.mem_v[3][step]); // op0 * op1


### PR DESCRIPTION
This PR should fix some bugs in the pc update constraints.
Changes:
- Fixed constraint `NEXT_PC_1` (missing parentheses were messing up the constraint evaluation). This should fix #9 
- Fixed constraint `T1`. This required to change how register `res` is computed in the case of a `jnz` instruction, in accordance with note 1. at p. 53 of the Cairo whitepaper